### PR TITLE
/api/timeの修正

### DIFF
--- a/response-post.go
+++ b/response-post.go
@@ -14,6 +14,10 @@ type TimeData struct {
 
 // /api/time にPOSTされた時の処理
 func postHandler(w http.ResponseWriter, r *http.Request) {
+
+    // ターミナルにリクエスト受信の通知を表示（追加）
+	fmt.Println("POSTリクエストを受信しました")
+
 	// OPTIONSリクエストの場合はCORSプリフライトとして処理
 	if r.Method == "OPTIONS" {
 		setCORS(w)

--- a/response-post.go
+++ b/response-post.go
@@ -14,10 +14,23 @@ type TimeData struct {
 
 // /api/time にPOSTされた時の処理
 func postHandler(w http.ResponseWriter, r *http.Request) {
+	// OPTIONSリクエストの場合はCORSプリフライトとして処理
+	if r.Method == "OPTIONS" {
+		setCORS(w)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// POSTメソッド以外はエラー
+	if r.Method != "POST" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	// フロントエンドからのアクセスを許可（CORS対応）
 	setCORS(w)
 
-    // 複数日付データを格納するマップを用意
+	// 複数日付データを格納するマップを用意
 	var data map[string]TimeData
 
 	// リクエストのJSONをTimeData構造体に変換（デコード）
@@ -32,5 +45,9 @@ func postHandler(w http.ResponseWriter, r *http.Request) {
 
 	// データをJSONに変換してレスポンスとして返す
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(data)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		http.Error(w, "JSONのエンコードに失敗しました", http.StatusInternalServerError)
+		fmt.Println("エンコードエラー:", err)
+		return
+	}
 }

--- a/utils.go
+++ b/utils.go
@@ -7,4 +7,6 @@ import (
 // フロントとバックで別々のドメインよりCORS設定
 func setCORS(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
 }


### PR DESCRIPTION
### 【実装】
CORS設定が不完全→POSTリクエストの場合のヘッダー設定を追加
POSTハンドラーのエラーハンドリングを改善

###  【目的】
前回のfeatでは、フロントエンド側の接続がうまくいかなかったので修正

### 【詳細】

・POSTリクエストのヘッダー設定を追加
```
// フロントとバックで別々のドメインよりCORS設定
func setCORS(w http.ResponseWriter) {
    w.Header().Set("Access-Control-Allow-Origin", "*")
    w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
    w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
}
```
[Access-Control-Allow-Methodsについて](https://developer.mozilla.org/ja/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Methods)
[Access-Control-Allow-Headersについて](https://developer.mozilla.org/ja/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Headers)
・POSTハンドラーのエラーハンドリングを改善
```
// /api/time にPOSTされた時の処理
func postHandler(w http.ResponseWriter, r *http.Request) {
    // OPTIONSリクエストの場合はCORSプリフライトとして処理
    if r.Method == "OPTIONS" {
        setCORS(w)
        w.WriteHeader(http.StatusOK)
        return
    }

    // POSTメソッド以外はエラー
    if r.Method != "POST" {
        http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
        return
    }
```

```
if err := json.NewEncoder(w).Encode(data); err != nil {
        http.Error(w, "JSONのエンコードに失敗しました", http.StatusInternalServerError)
        fmt.Println("エンコードエラー:", err)
        return
    }
```
[OPTIONリクエストについて](https://developer.mozilla.org/ja/docs/Web/HTTP/Reference/Methods/OPTIONS)
[プリフライトリクエストについて](https://developer.mozilla.org/ja/docs/Glossary/Preflight_request)