### PR TITLE
プロジェクト構造の改善（バックエンド内での責務分離）

### DIFF
--- a/firestore.go
+++ b/firestore.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+// TimeEntry は各イベントの開始時刻、終了時刻、順序を格納する構造体
+type TimeEntry struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
+	Order *int   `json:"order,omitempty"`
+}
+
+// processAndSaveSchedule: 受け取ったデータを解析・整形し、Firestoreに保存する
+func processAndSaveSchedule(ctx context.Context, requestData map[string]interface{}) (string, map[string][]TimeEntry, error) {
+	// Firestoreクライアントの存在確認
+	if client == nil {
+		return "", nil, fmt.Errorf("重大なエラー: Firestoreクライアントが初期化されていません")
+	}
+
+	// requestDateマップから"spaceID"というキーで値を取得
+	spaceIdInterface, ok := requestData["spaceId"]
+	if !ok {
+		return "", nil, fmt.Errorf("'spaceId' がリクエストデータに含まれていません")
+	}
+	spaceId := spaceIdInterface.(string)
+
+	// スケジュールデータの整理
+	// eventsToStore：Firestoreに保存するための、最終的なきれいなデータを格納する変数
+	eventsToStore := make(map[string][]TimeEntry)
+
+	// 外側ループ：requestDateからkeyが"spaceId"以外の者をループ処理
+	// key:"2025-06-12"等が、value： [{"start":...}] ような配列が入る
+	for key, value := range requestData {
+		if key == "spaceId" {
+			continue
+		}
+
+		// valueをinterface{}型から[]interface{}型に変換
+		eventList := value.([]interface{})
+
+		var dateEvents []TimeEntry
+		for i, eventInterface := range eventList {
+			eventMap, _ := eventInterface.(map[string]interface{})
+			startStr, _ := eventMap["start"].(string)
+			endStr, _ := eventMap["end"].(string)
+
+			// orderの処理 (orderが存在しない場合、デフォルト値 1 を設定)
+			var orderPtr *int
+			defaultValue := 1
+			if orderVal, exists := eventMap["order"]; exists {
+				if orderFloat, isFloat := orderVal.(float64); isFloat {
+					val := int(orderFloat)
+					orderPtr = &val
+				} else if orderInt, isInt := orderVal.(int); isInt {
+					orderPtr = &orderInt
+				} else {
+					return "", nil, fmt.Errorf("キー '%s' の %d 番目のイベントの 'order' が無効な形式です", key, i)
+				}
+			} else {
+				orderPtr = &defaultValue
+			}
+			dateEvents = append(dateEvents, TimeEntry{Start: startStr, End: endStr, Order: orderPtr})
+		}
+		eventsToStore[key] = dateEvents
+	}
+
+	// 保存すべきイベントがない場合は、処理を中断してその旨を返す
+	if len(eventsToStore) == 0 {
+		return spaceId, nil, nil
+	}
+
+	// Firestoreにデータを保存
+	docRef := client.Collection("schedules").Doc(spaceId)
+	_, err := docRef.Set(ctx, eventsToStore)
+	if err != nil {
+		return "", nil, fmt.Errorf("Firestoreへのデータ保存に失敗しました: %w", err)
+	}
+
+	return spaceId, eventsToStore, nil
+}

--- a/firestore_get.go
+++ b/firestore_get.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// response-get.goを用いて、DBを参照
+// データベースの特定の情報をフロントに返す処理
+func getScheduleFromFirestore(ctx context.Context, spaceId string) (map[string]interface{}, error) {
+	// Firestoreからデータを取得
+	docRef := client.Collection("schedules").Doc(spaceId)
+	doc, err := docRef.Get(ctx)
+	if err != nil {
+		// データが見つからないエラーの場合、データなし(nil)とエラーなしを返してハンドラ側で404を処理させる
+		if status.Code(err) == codes.NotFound {
+			return nil, nil
+		}
+		// その他のエラーの場合は、エラーをそのまま返す
+		return nil, err
+	}
+
+	return doc.Data(), nil
+}

--- a/firestore_post.go
+++ b/firestore_post.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+// response-post.goを用いて、DBに保存する処理
+func saveScheduleToFirestore(ctx context.Context, spaceId string, eventsToStore map[string][]TimeEntry) error {
+	// Firestoreクライアントの存在確認
+	if client == nil {
+		return fmt.Errorf("重大なエラー: Firestoreクライアントが初期化されていません")
+	}
+
+	// Firestoreにデータを保存
+	docRef := client.Collection("schedules").Doc(spaceId)
+	_, err := docRef.Set(ctx, eventsToStore)
+	if err != nil {
+		return fmt.Errorf("firestoreへのデータ保存に失敗しました: %w", err)
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	firebase.google.com/go/v4 v4.15.2
 	github.com/joho/godotenv v1.5.1
 	google.golang.org/api v0.215.0
+	google.golang.org/grpc v1.67.3
 )
 
 require (
@@ -57,6 +58,5 @@ require (
 	google.golang.org/genproto v0.0.0-20241118233622-e639e219e697 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241209162323-e6fa225c2576 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241223144023-3abc09e42ca8 // indirect
-	google.golang.org/grpc v1.67.3 // indirect
 	google.golang.org/protobuf v1.36.1 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -14,12 +14,14 @@ import (
 )
 
 var client *firestore.Client
+
+// 全体の処理の枠組み、フレームワーク
 func main() {
 
 	// .envファイルを読み込む
-	err := godotenv.Load() 
+	err := godotenv.Load()
 	if err != nil {
-		log.Fatalf("Error loading .env file: %v", err) 
+		log.Fatalf("Error loading .env file: %v", err)
 	}
 
 	// Firestoreクライアントの初期化
@@ -55,8 +57,9 @@ func main() {
 
 	fmt.Println("Firebase Admin SDKとFirestoreクライアントが正常に初期化されました。")
 
-	http.HandleFunc("/api/time", postHandler) // postHandlerは別途定義が必要です
-	http.HandleFunc("/api/time/", getHandler) // getHandlerは別途定義が必要です
+	// --- ルーティング ---
+	http.HandleFunc("/api/time", postHandler) // POSTリクエストのハンドラを登録
+	http.HandleFunc("/api/time/", getHandler) // GETリクエストのハンドラを登録
 	fmt.Println("Listening on :8080")
 
 	log.Fatal(http.ListenAndServe(":8080", nil))

--- a/response-post.go
+++ b/response-post.go
@@ -1,27 +1,19 @@
 package main
 
 import (
-	"context" // Firestore操作に必要
 	"encoding/json"
 	"fmt"
 	"net/http"
-	// "time" // 日付や時刻のバリデーションを行う場合に必要
 )
 
-// 各イベントの開始時刻、終了時刻、および順序を格納する構造体
-type TimeEntry struct {
-	Start string `json:"start"`
-	End   string `json:"end"`
-	Order *int   `json:"order,omitempty"` // orderはオプションなのでポインタ型
-}
-
-// /api/time にPOSTされた時の処理
+// /api/time にPOSTでリクエストが来た時の処理
 func postHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Println("POSTリクエストを受信しました")
+	setCORS(w) // CORSヘッダーを設定
 
-	// OPTIONSリクエストの場合はCORSプリフライトとして処理
+	// 正当なリクエストだけ受け付ける処理
+	// OPTIONSメソッドのチェック
 	if r.Method == http.MethodOptions {
-		setCORS(w)
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -32,118 +24,26 @@ func postHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	setCORS(w)
-
+	// JSONデータの受信と解析
 	var requestData map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&requestData); err != nil {
 		http.Error(w, "JSONの解析に失敗しました: "+err.Error(), http.StatusBadRequest)
-		fmt.Println("デコードエラー:", err)
 		return
 	}
 	defer r.Body.Close()
 
-	fmt.Printf("受信した生データ: %+v\n", requestData)
-
-	spaceIdInterface, ok := requestData["spaceId"]
-	if !ok {
-		http.Error(w, "'spaceId' がリクエストデータに含まれていません", http.StatusBadRequest)
-		fmt.Println("エラー: 'spaceId' が見つかりません")
-		return
-	}
-	spaceId, ok := spaceIdInterface.(string)
-	if !ok || spaceId == "" {
-		http.Error(w, "'spaceId' は空でない文字列である必要があります", http.StatusBadRequest)
-		fmt.Println("エラー: 'spaceId' が文字列でないか、空です")
+	// 解析したデータを渡し、Firestoreへの保存処理を呼び出す
+	spaceId, savedEvents, err := processAndSaveSchedule(r.Context(), requestData)
+	if err != nil {
+		http.Error(w, "データの処理または保存に失敗しました: "+err.Error(), http.StatusInternalServerError)
+		fmt.Printf("処理エラー: %v\n", err)
 		return
 	}
 
-	eventsToStore := make(map[string][]TimeEntry)
+	w.Header().Set("Content-Type", "application/json")
 
-	for key, value := range requestData {
-		if key == "spaceId" {
-			continue
-		}
-
-		eventListInterface, ok := value.([]interface{})
-		if !ok {
-			errMsg := fmt.Sprintf("キー '%s' のデータ形式が無効です。イベントの配列形式である必要があります。", key)
-			http.Error(w, errMsg, http.StatusBadRequest)
-			fmt.Printf("エラー: キー '%s' の値が予期した配列形式ではありません: %+v\n", key, value)
-			return
-		}
-
-		var dateEvents []TimeEntry
-
-		for i, eventInterface := range eventListInterface {
-			eventMap, ok := eventInterface.(map[string]interface{})
-			if !ok {
-				errMsg := fmt.Sprintf("キー '%s' の配列の %d 番目の要素のデータ形式が無効です。オブジェクト形式である必要があります。", key, i)
-				http.Error(w, errMsg, http.StatusBadRequest)
-				fmt.Printf("エラー: キー '%s' の配列の %d 番目の要素がマップ形式ではありません: %+v\n", key, i, eventInterface)
-				return
-			}
-
-			startStrInterface, startExists := eventMap["start"]
-			endStrInterface, endExists := eventMap["end"]
-
-			if !startExists || !endExists {
-				errMsg := fmt.Sprintf("キー '%s' の配列の %d 番目のイベントに 'start' または 'end' が含まれていません。", key, i)
-				http.Error(w, errMsg, http.StatusBadRequest)
-				fmt.Printf("エラー: キー '%s' の配列の %d 番目のイベントデータに 'start' または 'end' がありません: %+v\n", key, i, eventMap)
-				return
-			}
-
-			startStr, startOk := startStrInterface.(string)
-			endStr, endOk := endStrInterface.(string)
-
-			if !startOk || !endOk {
-				errMsg := fmt.Sprintf("キー '%s' の配列の %d 番目のイベントの 'start' または 'end' の形式が無効です。文字列である必要があります。", key, i)
-				http.Error(w, errMsg, http.StatusBadRequest)
-				fmt.Printf("エラー: キー '%s' の配列の %d 番目のイベントの 'start' または 'end' が文字列ではありません: %+v\n", key, i, eventMap)
-				return
-			}
-
-			var orderPtr *int
-			if orderInterface, orderExists := eventMap["order"]; orderExists {
-				orderFloat, orderIsFloat := orderInterface.(float64)
-				if orderIsFloat {
-					orderVal := int(orderFloat)
-					orderPtr = &orderVal
-				} else {
-					orderInt, orderIsInt := orderInterface.(int)
-					if orderIsInt {
-						orderVal := int(orderInt)
-						orderPtr = &orderVal
-					} else {
-						errMsg := fmt.Sprintf("キー '%s' の配列の %d 番目のイベントの 'order' の形式が無効です。数値である必要があります。", key, i)
-						http.Error(w, errMsg, http.StatusBadRequest)
-						fmt.Printf("エラー: キー '%s' の配列の %d 番目のイベントの 'order' が数値ではありません (型: %T): %+v\n", key, i, orderInterface, eventMap)
-						return
-					}
-				}
-			} else {
-				// ★★★ 変更点: orderが存在しない場合、デフォルト値 1 を設定 ★★★
-				defaultValue := 1
-				orderPtr = &defaultValue
-			}
-
-			dateEvents = append(dateEvents, TimeEntry{Start: startStr, End: endStr, Order: orderPtr})
-		}
-		eventsToStore[key] = dateEvents
-	}
-
-	fmt.Printf("抽出した spaceId: %s\n", spaceId)
-	fmt.Printf("Firestoreに保存するイベントデータ: %+v\n", eventsToStore)
-
-	if client == nil {
-		http.Error(w, "Firestoreクライアントが初期化されていません", http.StatusInternalServerError)
-		fmt.Println("重大なエラー: Firestoreクライアント (global 'client') がnilです")
-		return
-	}
-
-	if len(eventsToStore) == 0 {
-		fmt.Printf("spaceId '%s' に関連する有効なカレンダーイベントが見つかりませんでした。Firestoreへの保存は行いません。\n", spaceId)
-		w.Header().Set("Content-Type", "application/json")
+	// 保存する有効なイベントがなかった場合のレスポンス
+	if len(savedEvents) == 0 {
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(map[string]string{
 			"message": "有効なカレンダーイベントデータが見つかりませんでした。",
@@ -152,23 +52,15 @@ func postHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	docRef := client.Collection("schedules").Doc(spaceId)
-	_, err := docRef.Set(context.Background(), eventsToStore)
-	if err != nil {
-		http.Error(w, "Firestoreへのデータ保存に失敗しました: "+err.Error(), http.StatusInternalServerError)
-		fmt.Printf("Firestore Setエラー (spaceId: %s, Collection: schedules): %v\n", spaceId, err)
-		return
-	}
-
-	fmt.Printf("データがFirestoreに正常に保存されました。Collection: schedules, Document ID: %s\n", spaceId)
-
-	w.Header().Set("Content-Type", "application/json")
+	// 成功した場合のレスポンス
+	w.WriteHeader(http.StatusOK)
 	response := map[string]interface{}{
-		"message":     "データは正常に受信され、Firestoreに保存されました。",
-		"spaceId":     spaceId,
-		"savedEvents": eventsToStore,
+		"message":   "データは正常に受信され、Firestoreに保存されました。",
+		"spaceId":   spaceId,
+		"savedEvents": savedEvents,
 	}
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		fmt.Println("レスポンスのJSONエンコードに失敗しました:", err)
 	}
+	fmt.Printf("データがFirestoreに正常に保存されました。Document ID: %s\n", spaceId)
 }


### PR DESCRIPTION
# Goの構造改善

## 1. 目的
各機能を追加する度に一ファイルの責任が多くなっていた。将来的にプロジェクトが拡張していくことを見据え、可読性と保守性を向上させることを目的に、ファイル分割を行う。

- **責務の分離**: 1つのファイルに複数の役割（HTTPリクエスト受付、データ加工、DB通信など）が混在している状態を改善する。
- **可読性の向上**: 各ファイルが持つ役割を明確にし、コードを読む際の可読性を向上することで、新規メンバーでも理解しやすい構造にする。
- **保守性の向上**: 機能の追加や修正を行う際、影響範囲を特定しやすくする。例えば、「DBの保存処理だけを変更したい」場合に、firestore_post.go のみを修正すればよい、といった状態にしたい。

## 2. 各ファイルの役割
プロジェクトは以下のファイル群に分割され、それぞれが明確な役割を持つ。

### ①`main.go` （バックエンド全体起動と初期設定）
アプリケーション全体の土台となるファイル。
- **主な責務**:
    - 環境変数の読み込み
    - Firebase/Firestoreクライアントの初期化とDBセッションの管理
    - HTTPサーバーの起動
    - APIエンドポイントの紐づけ（URLと担当ハンドラ関数の紐付け）

### ②`handler_get.go` と `handler_post.go` （リクエストの受付窓口）
HTTPリクエストを直接受け取る「受付窓口」の役割を担う。**クライアントとの通信**に特化しており、具体的なデータ処理やDBの仕組みについては関与しない。
- **主な責務**:
    - CORSや許可するHTTPメソッド（GET, POST）のチェック
    - URLからパラメータ（spaceIdなど）の抽出
    - リクエストボディ（JSON）の読み取り
    - 後続の処理（データ加工やDB通信）を適切な関数に依頼する
    - 最終的な処理結果をクライアントにHTTPレスポンスとして返却する

###  ③`post_transformer.go` （データの加工と整形）
handler_post.go が受け取った生のデータを、アプリケーション内部で扱いやすい形式（構造体）に変換する「データ加工専門」のファイル。
- **主な責務**:
    - リクエストデータから必要な値（spaceId や日付ごとのイベント）を抽出する
    - データを扱いやすい TimeEntry 構造体にマッピングする
    - order のようなオプション項目のデフォルト値を設定する

###  ④`firestore_get.go` と `firestore_post.go` （データベースとの通信）
**Firestoreとの通信**にのみ責任を持つファイル群。HTTPリクエストには関与せず、依頼されたデータの読み書きのみを実行する。
- **主な責務 (firestore_post.go)**:
    - post_transformer.go で整形されたデータをFirestoreに保存（Set）する
- **主な責務 (firestore_get.go)**:
    - 指定された **spaceId**を元にFirestoreからデータを取得（Get）する

###  ⑤`utils.go` （共通のインフラ関数のファイル）
特定の責務に属さない、プロジェクト横断で利用される共通関数を格納する。
- **主な責務**:
    - CORSヘッダーを設定するヘルパー関数の提供

## 3. 処理の流れ
この構造により、リクエストからレスポンスまでが一方通行になり、直感的なデータフローの理解がしやすくなる。

### ☆POSTリクエストの流れ
Client → handler_post.go → post_transformer.go → firestore_post.go → Firestore

### ☆GETリクエストの流れ
Client → handler_get.go → firestore_get.go → Firestore