### PR TITLE
ユーザー識別機能のバックエンド実装 

### DIFF
--- a/firestore_client.go
+++ b/firestore_client.go
@@ -8,12 +8,14 @@ import (
 
 	"cloud.google.com/go/firestore"
 	firebase "firebase.google.com/go/v4"
+	"firebase.google.com/go/v4/auth"
 	"github.com/joho/godotenv"
 	"google.golang.org/api/option"
 )
 
-// この 'client' 変数がプロジェクト全体で共有される
-var client *firestore.Client
+// FirestoreとAuthのクライアントをプロジェクト全体で共有する
+var firestoreClient *firestore.Client
+var authClient *auth.Client
 
 func init() {
 	_ = godotenv.Load() // .envファイルはローカル開発でのみ使用。エラーは無視。
@@ -33,9 +35,15 @@ func init() {
 		log.Fatalf("Firebase Admin SDKの初期化に失敗しました: %v", err)
 	}
 
-	client, err = app.Firestore(ctx)
+	firestoreClient, err = app.Firestore(ctx)
 	if err != nil {
 		log.Fatalf("Firestoreクライアントの取得に失敗しました: %v", err)
 	}
-	log.Println("Firestore client initialized successfully.")
+
+	authClient, err = app.Auth(ctx)
+	if err != nil {
+		log.Fatalf("Authクライアントの取得に失敗しました: %v", err)
+	}
+
+	log.Println("Firestore and Auth clients initialized successfully.")
 }

--- a/firestore_get.go
+++ b/firestore_get.go
@@ -11,7 +11,7 @@ import (
 // データベースの特定の情報をフロントに返す処理
 func getScheduleFromFirestore(ctx context.Context, spaceId string) (map[string]interface{}, error) {
 	// Firestoreからデータを取得
-	docRef := client.Collection(firestoreCollectionName).Doc(spaceId)
+	docRef := firestoreClient.Collection(firestoreCollectionName).Doc(spaceId)
 	doc, err := docRef.Get(ctx)
 	if err != nil {
 		// データが見つからないエラーの場合、データなし(nil)とエラーなしを返してハンドラ側で404を処理させる

--- a/firestore_save.go
+++ b/firestore_save.go
@@ -9,7 +9,7 @@ import (
 // saveScheduleToFirestore は、指定されたspaceIdのドキュメントとしてデータをFirestoreに保存します。
 // 既存のドキュメントがある場合は、完全に上書きされます。
 func saveScheduleToFirestore(ctx context.Context, spaceId string, data *ScheduleDocument) error {
-	docRef := client.Collection(firestoreCollectionName).Doc(spaceId)
+	docRef := firestoreClient.Collection(firestoreCollectionName).Doc(spaceId)
 	
 	// .Set() メソッドは構造体を渡すと、自動的にFirestoreのドキュメント形式に変換します。
 	_, err := docRef.Set(ctx, data)

--- a/gatekeeper.go
+++ b/gatekeeper.go
@@ -1,17 +1,10 @@
 package main
 
 import (
-	"context"
 	"log"
 	"net/http"
 	"strings"
 )
-
-// userContextKey はコンテキスト内でユーザーIDを格納するためのキーです。
-// 文字列リテラルを直接使うのを避け、型安全性を高めるためのテクニックです。
-type userContextKey string
-
-const uidContextKey = userContextKey("uid")
 
 // optionalAuthMiddleware はHTTPリクエストを"オプショナル"で認証するミドルウェアです。
 func optionalAuthMiddleware(next http.Handler) http.Handler {
@@ -40,13 +33,7 @@ func optionalAuthMiddleware(next http.Handler) http.Handler {
 		}
 
 		// 検証成功: コンテキストにUIDを保存して次のハンドラを呼び出す
-		ctx := context.WithValue(r.Context(), uidContextKey, token.UID)
+		ctx := setUIDInContext(r.Context(), token.UID)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
-}
-
-// getUIDFromContext はコンテキストからUIDを取得します。後のステップで使います。
-func getUIDFromContext(ctx context.Context) (string, bool) {
-	uid, ok := ctx.Value(uidContextKey).(string)
-	return uid, ok
 }

--- a/gatekeeper.go
+++ b/gatekeeper.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// userContextKey はコンテキスト内でユーザーIDを格納するためのキーです。
+// 文字列リテラルを直接使うのを避け、型安全性を高めるためのテクニックです。
+type userContextKey string
+
+const uidContextKey = userContextKey("uid")
+
+// optionalAuthMiddleware はHTTPリクエストを"オプショナル"で認証するミドルウェアです。
+func optionalAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get("Authorization")
+		if authHeader == "" {
+			// ヘッダーがなければ、非ログインユーザーとして次の処理へ
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// "Bearer " プレフィックスを検証・削除
+		parts := strings.Split(authHeader, " ")
+		if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
+			log.Println("WARN: Authorization header format is invalid, proceeding as anonymous.")
+			next.ServeHTTP(w, r) // フォーマット不正でもエラーにせず、非ログインユーザーとして続行
+			return
+		}
+		idToken := parts[1]
+
+		token, err := authClient.VerifyIDToken(r.Context(), idToken)
+		if err != nil {
+			log.Printf("WARN: Failed to verify ID token, proceeding as anonymous: %v\n", err)
+			next.ServeHTTP(w, r) // トークン検証失敗でもエラーにせず、非ログインユーザーとして続行
+			return
+		}
+
+		// 検証成功: コンテキストにUIDを保存して次のハンドラを呼び出す
+		ctx := context.WithValue(r.Context(), uidContextKey, token.UID)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// getUIDFromContext はコンテキストからUIDを取得します。後のステップで使います。
+func getUIDFromContext(ctx context.Context) (string, bool) {
+	uid, ok := ctx.Value(uidContextKey).(string)
+	return uid, ok
+}

--- a/handler_post.go
+++ b/handler_post.go
@@ -6,32 +6,60 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/aws/aws-lambda-go/events"
 )
 
 func processPostRequest(ctx context.Context, req interface{}) (map[string]interface{}, int) {
-	var requestData map[string]interface{}
+	var bodyBytes []byte
 	var err error
 
+	// リクエストソース（ローカルサーバー or Lambda）に応じてリクエストボディをバイトスライスとして取得
 	switch r := req.(type) {
 	case *http.Request:
-		err = json.NewDecoder(r.Body).Decode(&requestData)
+		bodyBytes, err = io.ReadAll(r.Body)
+		if err != nil {
+			fmt.Printf("リクエストボディの読み取りに失敗: %v\n", err)
+			return map[string]interface{}{"error": "リクエストの処理に失敗しました"}, http.StatusInternalServerError
+		}
 		defer r.Body.Close()
 	case events.APIGatewayProxyRequest:
-		err = json.Unmarshal([]byte(r.Body), &requestData)
+		bodyBytes = []byte(r.Body)
 	default:
 		return map[string]interface{}{"error": "不明なリクエストタイプです"}, http.StatusInternalServerError
 	}
 
-	if err != nil {
+	// JSONを構造体にデコード
+	var postData SchedulePostRequest
+	if err := json.Unmarshal(bodyBytes, &postData); err != nil {
 		return map[string]interface{}{"error": "JSONの解析に失敗しました: " + err.Error()}, http.StatusBadRequest
 	}
 
-	spaceId, scheduleDoc, err := transformScheduleData(requestData)
-	if err != nil {
-		return map[string]interface{}{"error": "データ形式の解析に失敗しました: " + err.Error()}, http.StatusBadRequest
+	// バリデーション
+	if postData.SpaceID == "" {
+		return map[string]interface{}{"error": "'spaceId' がリクエストデータに含まれていないか、空です"}, http.StatusBadRequest
+	}
+
+	// Events内の各TimeEntryでOrderが指定されていない場合にデフォルト値を設定
+	defaultValue := 1
+	if postData.Events != nil {
+		for _, eventList := range postData.Events {
+			for i := range eventList {
+				if eventList[i].Order == nil {
+					eventList[i].Order = &defaultValue
+				}
+			}
+		}
+	}
+
+	// Firestoreに保存するドキュメントを作成
+	scheduleDoc := &ScheduleDocument{
+		AllowOtherEdit: postData.AllowOtherEdit,
+		StartDate:      postData.StartDate,
+		EndDate:        postData.EndDate,
+		Events:         postData.Events,
 	}
 
 	// コンテキストからUIDを取得し、存在すればドキュメントにセットする
@@ -40,16 +68,16 @@ func processPostRequest(ctx context.Context, req interface{}) (map[string]interf
 		scheduleDoc.OwnerUID = uid
 	}
 
-	if err := saveScheduleToFirestore(ctx, spaceId, scheduleDoc); err != nil {
-		fmt.Printf("処理エラー: %v\n", err)
-		return map[string]interface{}{"error": "データの処理または保存に失敗しました: " + err.Error()}, http.StatusInternalServerError
+	if err := saveScheduleToFirestore(ctx, postData.SpaceID, scheduleDoc); err != nil {
+		fmt.Printf("Firestoreへの保存エラー: %v\n", err)
+		return map[string]interface{}{"error": "データの保存に失敗しました: " + err.Error()}, http.StatusInternalServerError
 	}
 
-	fmt.Printf("データがFirestoreに正常に保存されました。Document ID: %s\n", spaceId)
+	fmt.Printf("データがFirestoreに正常に保存されました。Document ID: %s\n", postData.SpaceID)
 
 	return map[string]interface{}{
 		"message":   "データは正常に受信され、Firestoreに保存されました。",
-		"spaceId":   spaceId,
+		"spaceId":   postData.SpaceID,
 		"savedData": scheduleDoc,
 	}, http.StatusOK
 }

--- a/handler_post.go
+++ b/handler_post.go
@@ -34,6 +34,12 @@ func processPostRequest(ctx context.Context, req interface{}) (map[string]interf
 		return map[string]interface{}{"error": "データ形式の解析に失敗しました: " + err.Error()}, http.StatusBadRequest
 	}
 
+	// コンテキストからUIDを取得し、存在すればドキュメントにセットする
+	// ミドルウェアにより、ログインユーザーの場合のみUIDがセットされている
+	if uid, ok := getUIDFromContext(ctx); ok {
+		scheduleDoc.OwnerUID = uid
+	}
+
 	if err := saveScheduleToFirestore(ctx, spaceId, scheduleDoc); err != nil {
 		fmt.Printf("処理エラー: %v\n", err)
 		return map[string]interface{}{"error": "データの処理または保存に失敗しました: " + err.Error()}, http.StatusInternalServerError

--- a/post_transformer.go
+++ b/post_transformer.go
@@ -2,11 +2,15 @@
 
 package main
 
-import (
-	"fmt"
-	"log"
-	"time"
-)
+// SchedulePostRequest は、POSTリクエストのJSONボディの構造を定義します。
+// これにより、型安全なデコードが可能になります。
+type SchedulePostRequest struct {
+	SpaceID        string                 `json:"spaceId"`
+	AllowOtherEdit bool                   `json:"allowOtherEdit"`
+	StartDate      *string                `json:"startDate,omitempty"`
+	EndDate        *string                `json:"endDate,omitempty"`
+	Events         map[string][]TimeEntry `json:"events"`
+}
 
 // Firestoreに保存する際のキー名を小文字にするため、`firestore`タグを追加
 type TimeEntry struct {
@@ -19,100 +23,9 @@ type TimeEntry struct {
 
 // StartDateとEndDateをポインタ型(*string)にし、omitemptyタグを追加
 type ScheduleDocument struct {
-	OwnerUID       string                 `firestore:"ownerUid,omitempty"`
+	OwnerUID       string                 `json:"ownerUid,omitempty" firestore:"ownerUid,omitempty"`
 	AllowOtherEdit bool                   `firestore:"allowOtherEdit"`
 	StartDate      *string                `firestore:"startDate,omitempty"`
 	EndDate        *string                `firestore:"endDate,omitempty"`
 	Events         map[string][]TimeEntry `firestore:"events"`
-}
-
-func transformScheduleData(requestData map[string]interface{}) (string, *ScheduleDocument, error) {
-	spaceIdInterface, ok := requestData["spaceId"]
-	if !ok {
-		return "", nil, fmt.Errorf("'spaceId' がリクエストデータに含まれていません")
-	}
-	spaceId, ok := spaceIdInterface.(string)
-	if !ok || spaceId == "" {
-		return "", nil, fmt.Errorf("'spaceId' が無効です")
-	}
-
-	allowEdit, _ := requestData["allowOtherEdit"].(bool)
-
-	// ★★★ 変更点 ★★★
-	// startDateとendDateをポインタとして処理
-	var startDatePtr, endDatePtr *string
-	if val, ok := requestData["startDate"]; ok && val != nil {
-		if strVal, isString := val.(string); isString {
-			startDatePtr = &strVal
-		}
-	}
-	if val, ok := requestData["endDate"]; ok && val != nil {
-		if strVal, isString := val.(string); isString {
-			endDatePtr = &strVal
-		}
-	}
-
-	eventsToStore := make(map[string][]TimeEntry)
-	if eventsInterface, ok := requestData["events"]; ok {
-		if eventsMap, isMap := eventsInterface.(map[string]interface{}); isMap {
-			for key, value := range eventsMap {
-				// キーが日付形式か簡易チェック
-				if _, err := time.Parse("2006-01-02", key); err != nil {
-					log.Printf("INFO: 'events' 内のキー '%s' は日付形式ではないため、スキップします。", key)
-					continue
-				}
-
-				eventList, ok := value.([]interface{})
-				if !ok {
-					log.Printf("WARN: キー '%s' の値がイベントの配列ではないため、スキップします。", key)
-					continue
-				}
-
-				var dateEvents []TimeEntry
-				for i, eventInterface := range eventList {
-					eventMap, ok := eventInterface.(map[string]interface{})
-					if !ok {
-						log.Printf("WARN: キー '%s' の %d 番目のイベントデータ形式が不正なため、スキップします。", key, i)
-						continue
-					}
-
-					startStr, _ := eventMap["start"].(string)
-					endStr, _ := eventMap["end"].(string)
-					username, _ := eventMap["username"].(string)
-					userColor, _ := eventMap["userColor"].(string)
-
-					var orderPtr *int
-					defaultValue := 1
-					if orderVal, exists := eventMap["order"]; exists {
-						if orderFloat, isFloat := orderVal.(float64); isFloat {
-							val := int(orderFloat)
-							orderPtr = &val
-						} else if orderInt, isInt := orderVal.(int); isInt {
-							orderPtr = &orderInt
-						}
-					} else {
-						orderPtr = &defaultValue
-					}
-
-					dateEvents = append(dateEvents, TimeEntry{
-						Start:     startStr,
-						End:       endStr,
-						Order:     orderPtr,
-						Username:  username,
-						UserColor: userColor,
-					})
-				}
-				eventsToStore[key] = dateEvents
-			}
-		}
-	}
-
-	scheduleDoc := &ScheduleDocument{
-		AllowOtherEdit: allowEdit,
-		StartDate:      startDatePtr,
-		EndDate:        endDatePtr,
-		Events:         eventsToStore,
-	}
-
-	return spaceId, scheduleDoc, nil
 }

--- a/post_transformer.go
+++ b/post_transformer.go
@@ -8,7 +8,6 @@ import (
 	"time"
 )
 
-// ★★★ 変更点 ★★★
 // Firestoreに保存する際のキー名を小文字にするため、`firestore`タグを追加
 type TimeEntry struct {
 	Start     string `json:"start"     firestore:"start"`
@@ -18,9 +17,9 @@ type TimeEntry struct {
 	UserColor string `json:"userColor" firestore:"userColor"`
 }
 
-// ★★★ 変更点 ★★★
 // StartDateとEndDateをポインタ型(*string)にし、omitemptyタグを追加
 type ScheduleDocument struct {
+	OwnerUID       string                 `firestore:"ownerUid,omitempty"`
 	AllowOtherEdit bool                   `firestore:"allowOtherEdit"`
 	StartDate      *string                `firestore:"startDate,omitempty"`
 	EndDate        *string                `firestore:"endDate,omitempty"`

--- a/utils.go
+++ b/utils.go
@@ -1,7 +1,10 @@
 // utils.go
 package main
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // ローカルサーバー用: http.ResponseWriterに直接CORSヘッダーを設定
 // (本番ビルドでは使われない)
@@ -19,4 +22,21 @@ func getCorsHeaders() map[string]string {
 		"Access-Control-Allow-Methods": "POST, GET, OPTIONS, PUT, DELETE",
 		"Access-Control-Allow-Headers": "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization",
 	}
+}
+
+// userContextKey は、コンテキストキーの衝突を避けるためのカスタム型です。
+type userContextKey string
+
+// uidContextKey は、コンテキスト内でユーザーIDを保存・取得するためのキーです。
+const uidContextKey userContextKey = "userUID"
+
+// setUIDInContext は、ユーザーIDを含む新しいコンテキストを生成します。
+func setUIDInContext(ctx context.Context, uid string) context.Context {
+	return context.WithValue(ctx, uidContextKey, uid)
+}
+
+// getUIDFromContext は、コンテキストからユーザーIDを取得します。
+func getUIDFromContext(ctx context.Context) (string, bool) {
+	uid, ok := ctx.Value(uidContextKey).(string)
+	return uid, ok
 }


### PR DESCRIPTION
## 【バックエンドにおけるオプショナル認証基盤の実装】
## 1. 目的
将来的な認可機能を見据え、APIでユーザーを識別し、データの所有者を記録するためのバックエンド基盤を構築した。
- 所有者の記録：ログインユーザーが作成したデータに、誰が作成したかを示す所有者情報 (ownerUid) を付与する。
- 柔軟なアクセス：ログインしていないゲストユーザーも、これまで通りAPIを自由に利用できる状態を維持する。
- 拡張性の確保：将来、特定のユーザーにのみ操作を許可するような、より高度な認可機能を導入するための土台を整える。
## 2. 実装内容
① 認証ミドルウェアの導入（`gatekeeper.go`）
ローカル開発サーバーにおいて、APIリクエストを途中でチェックする「検問所」として機能する認証ミドルウェア (optionalAuthMiddleware) を導入した。
リクエストヘッダーのAuthorization: Bearer <IDトークン>を検証する。
トークンが存在し、Firebaseによって有効だと確認された場合、そのユーザーのUIDを後続の処理で利用できるよう、リクエストのコンテキストに保存する。トークンが存在しない、または無効な場合でもエラーとはせず、ゲストユーザーとして処理を続行する。
② Lambdaハンドラの認証対応（`main_lambda.go`）
本番環境であるAWS Lambdaでもローカル環境と同様の認証を実現するため、Lambdaハンドラ関数内に同等の認証ロジックを実装した。これにより、デプロイ後も一貫した認証挙動が保証される。
③ データ所有者の記録（`handler_post.go`）
Firestoreに保存する構造体 (ScheduleDocument構造体) に、所有者IDを保存するためのOwnerUIDフィールドを追加した。データ保存処理 (`processPostRequest`) を修正し、認証ミドルウェアによってコンテキストにUIDが保存されている場合のみ、そのUIDをOwnerUIDフィールドにセットしてからFirestoreに保存するようにした。
## 3. 最終的な挙動
- ログインユーザー：フロントエンドから取得した有効なIDトークンを付けてPOSTリクエストを送ると、作成されたスケジュールデータにownerUidが記録される。
- ゲストユーザー：IDトークンなしでPOSTリクエストを送ると、ownerUidフィールドなしでデータが作成される。